### PR TITLE
Change test_dir to google_test_dir

### DIFF
--- a/README
+++ b/README
@@ -45,12 +45,12 @@ module should have a main block that runs basetest.main():
   if __name__ == '__main__':
     basetest.main()
 
-2. Add a setup requirement on google-apputils and set the test_dir option:
+2. Add a setup requirement on google-apputils and set the google_test_dir option:
   # In setup.py
   setup(
       ...
       setup_requires = ['google-apputils>=0.2'],
-      test_dir = 'tests',
+      google_test_dir = 'tests',
       )
 
 3. Run your tests:


### PR DESCRIPTION
Using test_dir does not work; the python setup.py google_test command will complain that there is no test directory specified. The comments in google.apputils.setup_command say to use google_test_dir.